### PR TITLE
feat: updated api

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Writing one large query per page doesn't organize well. Asynchronous data fetchi
 
 Why can't static data queries be written closer to the component too?
 
-`next-data-hooks` is a small and simple lib that lets you write React hooks for static data queries in next.js by lifting static props into React Context.
+`next-data-hooks` is a small and simple lib that lets you write React hooks for static data queries in Next.js by lifting static props into React Context.
 
 ## Example
 
-See [the example in this repo](https://github.com/ricokahler/next-data-hooks/tree/main/examples/next-data-hooks-example) for some ideas on how to organize your static data call using this hook.
+See [the example in this repo](https://github.com/ricokahler/next-data-hooks/tree/main/examples/next-data-hooks-example) for some ideas on how to organize your static data calls using this hook.
 
 ## Installation
 
@@ -76,10 +76,10 @@ const useBlogPost = createDataHook('BlogPost', async (context) => {
   return blogPost;
 });
 
-export default useBlogPost
+export default useBlogPost;
 ```
 
-2. Use the data hook in a component. Add it to a static prop in an array with other data hooks (if applicable).
+2. Use the data hook in a component. Add it to a static prop in an array with other data hooks to compose them downward.
 
 ```tsx
 import ComponentThatUsesDataHooks from '..';
@@ -125,8 +125,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
 export const getStaticProps: GetStaticProps = async (context) => {
   const dataHooksProps = await getDataHooksProps({
     context,
-    // this is an array of all data hooks from the `dataHooks`
-    // static prop. there can be more than one
+    // this is an array of all data hooks from the `dataHooks` static prop.
     //                             👇👇👇
     dataHooks: BlogPostComponent.dataHooks,
   });
@@ -135,7 +134,8 @@ export const getStaticProps: GetStaticProps = async (context) => {
     props: {
       // spread the props required by next-data-hooks
       ...dataHooksProps,
-      // add additional props here
+
+      // add additional props to Next.js here
     },
   };
 };

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ At the root, add a `.babelrc` file that contains the following:
 import { createDataHook } from 'next-data-hooks';
 
 // this context is the GetStaticPropsContext from 'next'
-//                                                             👇
+//                                                      👇
 const useBlogPost = createDataHook('BlogPost', async (context) => {
   const slug = context.params?.slug as string;
 
@@ -127,7 +127,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     context,
     // this is an array of all data hooks from the `dataHooks`
     // static prop. there can be more than one
-    //             👇👇👇
+    //                             👇👇👇
     dataHooks: BlogPostComponent.dataHooks,
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "next-data-hooks",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-data-hooks",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Use `getStaticProps` as react hooks",
   "private": true,
   "scripts": {

--- a/src/create-data-hook.test.tsx
+++ b/src/create-data-hook.test.tsx
@@ -55,7 +55,7 @@ it('returns a hook that pulls from the given key', () => {
   `);
 });
 
-it('throws if the data key could not be found', () => {
+it('throws if the context not be found', () => {
   const useData = createDataHook('DataKey', async () => null);
   const handleError = jest.fn();
 
@@ -77,5 +77,32 @@ it('throws if the data key could not be found', () => {
   const error = handleError.mock.calls[0][0];
   expect(error.message).toMatchInlineSnapshot(
     `"Could not find \`NextDataHooksContext\`. Ensure \`NextDataHooksProvider\` is configured correctly."`
+  );
+});
+
+it('throws if a data hook could not be found', () => {
+  const useData = createDataHook('DataKey', () => null);
+  const handleError = jest.fn();
+
+  function Foo() {
+    useData();
+
+    return null;
+  }
+
+  act(() => {
+    create(
+      <ErrorBoundary fallback={<></>} onError={handleError}>
+        <NextDataHooksContext.Provider value={{}}>
+          <Foo />
+        </NextDataHooksContext.Provider>
+      </ErrorBoundary>
+    );
+  });
+
+  expect(handleError).toHaveBeenCalled();
+  const error = handleError.mock.calls[0][0];
+  expect(error).toMatchInlineSnapshot(
+    `[Error: Did not find a data hook named "DataKey". Ensure it was provided to getDataHooksProps.]`
   );
 });

--- a/src/create-data-hook.ts
+++ b/src/create-data-hook.ts
@@ -26,7 +26,14 @@ function createDataHook<R>(
         'Could not find `NextDataHooksContext`. Ensure `NextDataHooksProvider` is configured correctly.'
       );
     }
-    return dataHooksContext[key];
+    const dataHooksValue = dataHooksContext[key];
+    if (!Object.keys(dataHooksContext).includes(key)) {
+      throw new Error(
+        `Did not find a data hook named "${key}". Ensure it was provided to getDataHooksProps.`
+      );
+    }
+
+    return dataHooksValue;
   }
 
   return Object.assign(useData, {

--- a/src/get-data-hooks-props.test.tsx
+++ b/src/get-data-hooks-props.test.tsx
@@ -17,7 +17,7 @@ it('returns a getStaticProps function that pulls and populates props', async () 
 
   const result = await getDataHooksProps({
     context: mockContext,
-    hooks: [useFoo, useBar],
+    dataHooks: [useFoo, useBar],
   });
 
   expect(result).toMatchInlineSnapshot(`
@@ -52,7 +52,10 @@ it('throws if it encounters two data hooks with the same key', async () => {
   let caught = false;
 
   try {
-    await getDataHooksProps({ context: mockContext, hooks: [useFoo, useBar] });
+    await getDataHooksProps({
+      context: mockContext,
+      dataHooks: [useFoo, useBar],
+    });
   } catch (e) {
     expect(e).toMatchInlineSnapshot(
       `[Error: Found duplicate hook key "Hook". Ensure all hook keys per \`createDatHooksProps\` call are unique.]`
@@ -72,7 +75,7 @@ it('throws if it the stub function is run', async () => {
   try {
     await getDataHooksProps({
       context: mockContext,
-      hooks: [useFoo],
+      dataHooks: [useFoo],
     });
   } catch (e) {
     caught = true;

--- a/src/get-data-hooks-props.ts
+++ b/src/get-data-hooks-props.ts
@@ -14,7 +14,12 @@ interface Params {
  */
 async function getDataHooksProps({ hooks, context }: Params) {
   const hookKeys: { [key: string]: boolean } = {};
-  for (const hook of hooks) {
+
+  // we allow the same function reference to be added to the array more than
+  // once so we de-dupe here
+  const deDupedHooks = Array.from(new Set(hooks));
+
+  for (const hook of deDupedHooks) {
     if (hookKeys[hook.key]) {
       throw new Error(
         `Found duplicate hook key "${hook.key}". Ensure all hook keys per \`createDatHooksProps\` call are unique.`

--- a/src/get-data-hooks-props.ts
+++ b/src/get-data-hooks-props.ts
@@ -5,19 +5,19 @@ type DataHook = ReturnType<typeof createDataHook>;
 
 interface Params {
   context: GetStaticPropsContext;
-  hooks: DataHook[];
+  dataHooks: DataHook[];
 }
 
 /**
  * Pulls the data from the next-data-hooks and returns the props to be received
  * by the NextDataHooksProvider
  */
-async function getDataHooksProps({ hooks, context }: Params) {
+async function getDataHooksProps({ dataHooks, context }: Params) {
   const hookKeys: { [key: string]: boolean } = {};
 
   // we allow the same function reference to be added to the array more than
   // once so we de-dupe here
-  const deDupedHooks = Array.from(new Set(hooks));
+  const deDupedHooks = Array.from(new Set(dataHooks));
 
   for (const hook of deDupedHooks) {
     if (hookKeys[hook.key]) {
@@ -29,7 +29,7 @@ async function getDataHooksProps({ hooks, context }: Params) {
   }
 
   const entries = await Promise.all(
-    hooks.map(async (hook) => {
+    dataHooks.map(async (hook) => {
       const data = await hook.getData(context);
       return [hook.key, data] as [string, any];
     })

--- a/src/next-data-hooks-provider.test.tsx
+++ b/src/next-data-hooks-provider.test.tsx
@@ -6,7 +6,7 @@ import getDataHooksProps from './get-data-hooks-props';
 import NextDataHooksProvider from './next-data-hooks-provider';
 
 it('Injects the data from data hooks into React Context.', async () => {
-  const useData = createDataHook('DataKey', () => ({ hello: 'world' }));
+  const useData = createDataHook('DataKey', async () => ({ hello: 'world' }));
   const dataHandler = jest.fn();
 
   function Foo() {
@@ -22,7 +22,7 @@ it('Injects the data from data hooks into React Context.', async () => {
   const mockContext: GetStaticPropsContext = { params: { mock: 'context' } };
   const props = await getDataHooksProps({
     context: mockContext,
-    hooks: [useData],
+    dataHooks: [useData],
   });
 
   act(() => {


### PR DESCRIPTION
I've been using this project heavily to build a large green-field next.js site. I really like the flow so far but I wanted to introduce some breaking changes before I advertise this lib more.

This one introduces a few breaking changes, and a small update.

1. Trying to access a data hook that has not been added to the `getDataHooksProps` will result in a throw now. Previously it would return `undefined`.
2. `getDataHooksProps({ hooks: [/* ... */] })` has been renamed to `getDataHooksProps({ dataHooks: [/* ... */] })`. This will bring it closer a pattern I started using in code.
3. `getDataHooksProps` now de-dupes functions references so the same function reference can be added more than once.

2 & 3 are designed to align with a new pattern I started using: A `dataHooks` static property. See the updated README.